### PR TITLE
Add pipeline schedules viewsets and allow listing project-scope resources across account

### DIFF
--- a/src/mist/api/__init__.py
+++ b/src/mist/api/__init__.py
@@ -531,5 +531,10 @@ def add_routes(configurator):
     configurator.add_route('api_v1_devops_job_trace',
                            '/api/v1/devops/{project}/jobs/{job}/trace')
 
+    configurator.add_route('api_v1_devops_pipeline_schedules',
+                           '/api/v1/devops/{project}/pipeline_schedules')
+    configurator.add_route('api_v1_devops_pipeline_schedule',
+                           '/api/v1/devops/{project}/pipeline_schedules/{schedule}')
+
     configurator.add_route('api_v1_devops_token',
                            '/api/v1/devops/token')

--- a/src/mist/api/devops/README.md
+++ b/src/mist/api/devops/README.md
@@ -1,0 +1,21 @@
+# DevOps API
+|No|Verb |URL|Params|Description|
+|:-:|:-:|:-:|:-:|:-:|
+|1| POST | /api/v1/devops/token | {token: TOKEN} | Create a SCM token |
+|2| GET | /api/v1/devops/token | - | Get the SCM token of the current user |
+|3| PUT | /api/v1/devops/token | {token: TOKEN} | Update the SCM token of the current user |
+|4| GET | /api/v1/devops/projects | - | Get the list of projects|
+|5| GET | /api/v1/devops/{project}/pipelines | - | Get the list of pipelines of a specific project|
+|6| POST | /api/v1/devops/{project}/pipelines | - | Trigger a new pipeline of a specific project|
+|7| GET | /api/v1/devops/{project}/pipelines/{pipeline} | - | Get a specific pipeline of a specific project|
+|8| DELETE | /api/v1/devops/{project}/pipelines/{pipeline} | - | Delete a specific pipeline of a specific project|
+|9| POST | /api/v1/devops/{project}/pipelines/{pipeline}/retry | - | Retry a pipeline|
+|10| POST | /api/v1/devops/{project}/pipelines/{pipeline}/cancel | - | Cancel a pipeline|
+|11| Get | /api/v1/devops/{project}/jobs | - | Get the list of jobs of a specific project|
+|12| Get | /api/v1/devops/{project}/jobs/{pipeline} | - | Get the list of jobs of a specific pipeline|
+|13| Get | /api/v1/devops/{project}/jobs/{job} | - | Get a specific job|
+|14| POST | /api/v1/devops/{project}/jobs/{job}/erase | - | Erase a specific job|
+|15| POST | /api/v1/devops/{project}/jobs/{job}/play | - | Play a specific job|
+|16| POST | /api/v1/devops/{project}/jobs/{job}/retry | - | Retry a specific job|
+|17| POST | /api/v1/devops/{project}/jobs/{job}/cancel | - | Cancel a specific job|
+|18| POST | /api/v1/devops/{project}/jobs/{job}/trace | - | Trace a specific job|

--- a/src/mist/api/devops/README.md
+++ b/src/mist/api/devops/README.md
@@ -19,3 +19,18 @@
 |16| POST | /api/v1/devops/{project}/jobs/{job}/retry | - | Retry a specific job|
 |17| POST | /api/v1/devops/{project}/jobs/{job}/cancel | - | Cancel a specific job|
 |18| POST | /api/v1/devops/{project}/jobs/{job}/trace | - | Trace a specific job|
+
+## Example
+```sh
+curl localhost/api/v1/devops/projects -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
+curl localhost/api/v1/devops/1/pipelines -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
+curl localhost/api/v1/devops/all/pipelines -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
+```
+
+## Dev
+
+```py
+import gitlab
+gl = gitlab.Gitlab(url="http://10.23.9.108", private_token="glpat-uMAq-Ykp9vUUMoNtWEYx")
+gl.projects.list()
+```

--- a/src/mist/api/devops/README.md
+++ b/src/mist/api/devops/README.md
@@ -23,8 +23,12 @@
 ## Example
 ```sh
 curl localhost/api/v1/devops/projects -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
-curl localhost/api/v1/devops/1/pipelines -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
+
+curl localhost/api/v1/devops/2/pipelines -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
 curl localhost/api/v1/devops/all/pipelines -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
+
+curl localhost/api/v1/devops/2/pipeline_schedules -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
+curl localhost/api/v1/devops/all/pipeline_schedules -H "Authorization: 1bf68df4f9dccf2134d86a942e040920952dccf4cb0a8f87fd1dc836d0486027"
 ```
 
 ## Dev

--- a/src/mist/api/devops/methods.py
+++ b/src/mist/api/devops/methods.py
@@ -5,7 +5,8 @@ from mist.api.devops.models import SCMToken
 
 
 def get_scm_token(request):
-    """Get user's SCM token
+    """
+    Get user's SCM token
 
     If a token was not registered/created yet, it returns None
     """
@@ -17,3 +18,63 @@ def get_scm_token(request):
         return None
     return obj.token
 
+
+def get_project_id_list(gc):
+    """
+    Get the project id list
+
+    Parameters:
+        gc: gitlab client
+    Returns:
+        List of project ids
+    """
+    projects = gc.projects.list(iterator=True)
+    res = []
+    for project in projects:
+        res.append(project.asdict()["id"])
+    return res
+
+
+def get_pipelines(gc, project_id):
+    """Get pipeline object list of a specific project"""
+
+    project = gc.projects.get(project_id, lazy=True)
+    pipelines_json = []
+    pipelines = project.pipelines.list()
+    for pipeline in pipelines:
+        pipelines_json.append(pipeline.asdict())
+    return pipelines_json
+
+
+def get_jobs(gc, project_id):
+    """Get job object list of a specific project"""
+
+    project = gc.projects.get(project_id, lazy=True)
+    jobs = project.jobs.list()
+
+    jobs_json = []
+    for job in jobs:
+        jobs_json.append(job.asdict())
+
+    return jobs_json
+
+
+def get_pipeline_schedules(gc, project_id):
+    """Get pipeline schedule object list of a specific project"""
+
+    project = gc.projects.get(project_id, lazy=True)
+    schedules_json = []
+    schedules = project.pipelineschedules.list()
+    for schedule in schedules:
+        schedules_json.append(schedule.asdict())
+    return schedules_json
+
+
+def get_default_branch(gc, project_id):
+    """Get default branch"""
+
+    project = gc.projects.get(project_id, lazy=True)
+    branches = project.branches.list()
+    for br in branches:
+        if br.asdict()["default"] == True:
+            return br

--- a/src/mist/api/devops/views.py
+++ b/src/mist/api/devops/views.py
@@ -3,9 +3,17 @@ from pyramid.response import Response
 
 from mist.api.auth.methods import user_from_request
 from mist.api.helpers import params_from_request, view_config
-from mist.api.devops.methods import get_scm_token
-from mist.api.devops.middleware import check_scm_token_middleware, get_project_id_list, get_pipelines, get_jobs, get_pipeline_schedules, get_default_branch
+from mist.api.devops.methods import (
+    get_scm_token,
+    get_project_id_list,
+    get_pipelines,
+    get_jobs,
+    get_pipeline_schedules,
+    get_default_branch,
+)
+from mist.api.devops.middleware import check_scm_token_middleware
 from mist.api.devops.models import SCMToken
+
 # from mist.api.exceptions import PolicyUnauthorizedError
 # from mist.api.exceptions import BadRequestError, KeyParameterMissingError, NotFoundError
 from mist.api.exceptions import RequiredParameterMissingError

--- a/src/mist/api/devops/views.py
+++ b/src/mist/api/devops/views.py
@@ -4,8 +4,12 @@ from pyramid.response import Response
 from mist.api.auth.methods import user_from_request
 from mist.api.helpers import params_from_request, view_config
 from mist.api.devops.methods import get_scm_token
-from mist.api.devops.middleware import check_scm_token_middleware
+from mist.api.devops.middleware import check_scm_token_middleware, get_project_id_list, get_pipelines, get_jobs, get_pipeline_schedules, get_default_branch
 from mist.api.devops.models import SCMToken
+# from mist.api.exceptions import PolicyUnauthorizedError
+# from mist.api.exceptions import BadRequestError, KeyParameterMissingError, NotFoundError
+from mist.api.exceptions import RequiredParameterMissingError
+
 import logging
 
 
@@ -30,6 +34,7 @@ def get_token(request):
         return token
     return Response("token doesn't exist", 404)
 
+
 @view_config(route_name='api_v1_devops_token',
              request_method='POST', renderer='json')
 def create_token(request):
@@ -52,6 +57,7 @@ def create_token(request):
         return POST_OK_RES
     except Exception as e:
         return Response(str(e), 500)
+
 
 @view_config(route_name='api_v1_devops_token',
              request_method='PUT', renderer='json')
@@ -94,7 +100,7 @@ def list_projects(request):
     projects = gc.projects.list(iterator=True)
     projects_json = []
     for project in projects:
-        projects_json.append(project.to_json())
+        projects_json.append(project.asdict())
     return projects_json
 
 
@@ -111,14 +117,13 @@ def list_pipelines(request):
 
     gc = request.gitlab_client
     project_id = request.matchdict['project']
-    project = gc.projects.get(project_id, lazy=True)
-    # project.trigger_pipeline('main', trigger_token)
-
-    pipelines = project.pipelines.list()
-
     pipelines_json = []
-    for pipeline in pipelines:
-        pipelines_json.append(pipeline.to_json())
+    if project_id == "all":
+        projects = get_project_id_list(gc)
+        for project_id in projects:
+            pipelines_json += get_pipelines(gc, project_id)
+    else:
+        pipelines_json = get_pipelines(gc, project_id)
     return pipelines_json
 
 
@@ -142,7 +147,7 @@ def trigger_pipeline(request):
     trigger = project.triggers.create({'description': 'mytrigger'})
 
     pipeline = project.trigger_pipeline('main', trigger.token, variables=variables)
-    return pipeline.to_json()
+    return pipeline.asdict()
 
 
 @view_config(route_name='api_v1_devops_pipeline', request_method='GET',
@@ -160,7 +165,7 @@ def get_pipeline(request):
     pipeline_id = request.matchdict['pipeline']
     project = gc.projects.get(project_id, lazy=True)
     pipeline = project.pipelines.get(pipeline_id)
-    return pipeline.to_json()
+    return pipeline.asdict()
 
 
 @view_config(route_name='api_v1_devops_pipeline', request_method='DELETE',
@@ -236,12 +241,14 @@ def list_project_jobs(request):
 
     gc = request.gitlab_client
     project_id = request.matchdict['project']
-    project = gc.projects.get(project_id, lazy=True)
-    jobs = project.jobs.list()
-
+    
     jobs_json = []
-    for job in jobs:
-        jobs_json.append(job.to_json())
+    if project_id == "all":
+        projects = get_project_id_list(gc)
+        for project_id in projects:
+            jobs_json += get_jobs(gc, project_id)
+    else:
+        jobs_json = get_jobs(gc, project_id)
     return jobs_json
 
 
@@ -264,7 +271,7 @@ def list_pipeline_jobs(request):
 
     jobs_json = []
     for job in jobs:
-        jobs_json.append(job.to_json())
+        jobs_json.append(job.asdict())
     return jobs_json
 
 
@@ -284,7 +291,7 @@ def get_pipeline(request):
     project = gc.projects.get(project_id, lazy=True)
     job = project.jobs.get(job_id)
 
-    return job.to_json()
+    return job.asdict()
 
 
 @view_config(route_name='api_v1_devops_job_erase', request_method='POST',
@@ -384,3 +391,156 @@ def trace_pipeline(request):
     job = project.jobs.get(job_id)
     return job.trace()
 
+
+############################################# Pipeline schedules
+@view_config(route_name='api_v1_devops_pipeline_schedules',request_method='GET',
+             renderer='json')
+@check_scm_token_middleware
+def list_pipeline_schedules(request):
+    """
+    Tags: pipeline_schedules
+    ---
+    List the piepeline schedules
+    """
+
+    gc = request.gitlab_client
+    project_id = request.matchdict['project']
+    schedules_json = []
+    if project_id == "all":
+        projects = get_project_id_list(gc)
+        for project_id in projects:
+            schedules_json += get_pipeline_schedules(gc, project_id)
+    else:
+        schedules_json = get_pipeline_schedules(gc, project_id)
+    return schedules_json
+
+
+@view_config(route_name='api_v1_devops_pipeline_schedules', request_method='POST',
+             renderer='json')
+@check_scm_token_middleware
+def create_pipeline_schedule(request):
+    """
+    Tags: pipeline_schedules
+    ---
+    Create a pipeline schedule
+    """
+
+    gc = request.gitlab_client
+    project_id = request.matchdict['project']
+    project = gc.projects.get(project_id, lazy=True)
+
+    params = params_from_request(request)
+    ref = params.get('ref', get_default_branch(gc, project_id))
+    desc = params.get('description', None)
+    cron = params.get('cron', None)
+
+    if not ref:
+        raise RequiredParameterMissingError("Target branch or tag is not provided")
+
+    if not desc:
+        raise RequiredParameterMissingError("Description is not provided")
+
+    if not cron:
+        raise RequiredParameterMissingError("Interval pattern is not provided")
+
+    schedule = project.pipelineschedules.create({
+        'ref': ref, # 'main',
+        'description': desc, # 'Daily test',
+        'cron': cron # '0 1 * * *'
+    })
+
+    return schedule.asdict()
+
+
+@view_config(route_name='api_v1_devops_pipeline_schedule', request_method='GET',
+             renderer='json')
+@check_scm_token_middleware
+def get_pipeline_schedule(request):
+    """
+    Tags: pipeline_schedules
+    ---
+    Get a pipeline schedule
+    """
+
+    gc = request.gitlab_client
+    project_id = request.matchdict['project']
+    schedule_id = request.matchdict['schedule']
+    project = gc.projects.get(project_id, lazy=True)
+    schedule = project.pipelineschedules.get(schedule_id)
+
+    return schedule.asdict()
+
+
+@view_config(route_name='api_v1_devops_pipeline_schedule', request_method='PUT',
+             renderer='json')
+@check_scm_token_middleware
+def update_pipeline_schedule(request):
+    """
+    Tags: pipeline_schedules
+    ---
+    Update a pipeline schedule
+    """
+
+    gc = request.gitlab_client
+    project_id = request.matchdict['project']
+    schedule_id = request.matchdict['schedule']
+    project = gc.projects.get(project_id, lazy=True)
+    schedule = project.pipelineschedules.get(schedule_id)
+
+    params = params_from_request(request)
+    ref = params.get('ref', get_default_branch(gc, project_id))
+    desc = params.get('description', None)
+    cron = params.get('cron', None)
+
+    if not ref:
+        schedule.ref = ref
+
+    if not desc:
+        schedule.desc = desc
+
+    if not cron:
+        schedule.cron = cron
+
+    schedule.save()
+
+    return schedule.asdict()
+
+
+@view_config(route_name='api_v1_devops_pipeline_schedule', request_method='DELETE',
+             renderer='json')
+@check_scm_token_middleware
+def delete_pipeline_schedule(request):
+    """
+    Tags: pipeline_schedules
+    ---
+    Delete a pipeline schedule
+    """
+
+    gc = request.gitlab_client
+    project_id = request.matchdict['project']
+    schedule_id = request.matchdict['schedule']
+    project = gc.projects.get(project_id, lazy=True)
+    schedule = project.pipelineschedules.get(schedule_id)
+    schedule.delete()
+
+    return OK_RES
+
+
+@view_config(route_name='api_v1_devops_pipeline_schedule', request_method='POST',
+             renderer='json')
+@check_scm_token_middleware
+def play_pipeline_schedule(request):
+    """
+    Tags: pipeline_schedules
+    ---
+    Play a pipeline schedule
+    """
+
+    gc = request.gitlab_client
+    project_id = request.matchdict['project']
+    schedule_id = request.matchdict['schedule']
+    project = gc.projects.get(project_id, lazy=True)
+    schedule = project.pipelineschedules.get(schedule_id)
+    schedule.play()
+
+    return POST_OK_RES


### PR DESCRIPTION
by passing `all` as project_id, you can get all resources of your account.
For example, you can get all pipelines belonging to any projects owned by your account by using `/api/v1/devops/all/pipelines` url. To get pipelins belonging to a specific project, `/api/v1/devops/2/pipelines` and `2` is the project id in this example.